### PR TITLE
Defer packet input processing to thread context

### DIFF
--- a/module.json
+++ b/module.json
@@ -29,7 +29,8 @@
   ],
   "dependencies": {
     "sal-stack-lwip": "^1.0.0",
-    "sal-iface-eth": "^1.0.0"
+    "sal-iface-eth": "^1.0.0",
+    "minar": "^1.0.1"
   },
   "targetDependencies": {}
 }

--- a/source/defer_input.h
+++ b/source/defer_input.h
@@ -1,0 +1,25 @@
+/*
+ * K64F EMAC lwIP driver
+ * Copyright (c) 2015, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SAL_DRIVER_LWIP_K64F_SOURCE_DEFER_INPUT_H
+#define SAL_DRIVER_LWIP_K64F_SOURCE_DEFER_INPUT_H
+#include "lwip/pbuf.h"
+#include "netif/etharp.h"
+extern "C"
+void defer_input(struct pbuf *p, struct netif *netif);
+#endif // SAL_DRIVER_LWIP_K64F_SOURCE_DEFER_INPUT_H

--- a/source/deferred_input.cpp
+++ b/source/deferred_input.cpp
@@ -1,0 +1,38 @@
+/*
+ * K64F EMAC lwIP driver
+ * Copyright (c) 2015, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "minar/minar.h"
+#include "lwip/pbuf.h"
+#include "netif/etharp.h"
+#include "defer_input.h"
+
+void call_input(struct pbuf *p, struct netif *netif)
+{
+    /* full packet send to tcpip_thread to process */
+    if (netif->input(p, netif) != ERR_OK) {
+      LWIP_DEBUGF(NETIF_DEBUG, ("k64f_enetif_input: IP input error\n"));
+      /* Free buffer */
+      pbuf_free(p);
+    }
+}
+
+void defer_input(struct pbuf *p, struct netif *netif)
+{
+    minar::Scheduler::postCallback(
+        mbed::util::FunctionPointer2<void, struct pbuf *, struct netif *>(call_input)
+          .bind(p, netif));
+}

--- a/source/k64f_emac.c
+++ b/source/k64f_emac.c
@@ -482,14 +482,8 @@ void k64f_enetif_input(struct netif *netif, int idx)
     case ETHTYPE_PPPOEDISC:
     case ETHTYPE_PPPOE:
 #endif /* PPPOE_SUPPORT */
-      /* full packet send to tcpip_thread to process */
-      if (netif->input(p, netif) != ERR_OK) {
-        LWIP_DEBUGF(NETIF_DEBUG, ("k64f_enetif_input: IP input error\n"));
-        /* Free buffer */
-        pbuf_free(p);
-      }
-      break;
-
+        defer_input(p, netif);
+        break;
     default:
       /* Return buffer */
       pbuf_free(p);


### PR DESCRIPTION
add a dependency on the scheduler.
Add a new file that schedules ```netif->input```
Call ```defer_input``` instead of ```netif->input```

cc @bogdanm @lws-team

This is a possible fix for https://github.com/ARMmbed/sal-driver-lwip-k64f-eth/issues/8 and https://github.com/ARMmbed/sockets/issues/41