### PR TITLE
Remove malloc from IRQ context in k64f ethernet driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Restored
+- [v1.0.4]
+### Fixed
+- Replaced `pbuf_alloc` with `memp_malloc` in `k64f_low_level_output`, which will fix the problem that required [v1.0.4] to be reverted.
+
 ## [v1.0.5]
 ### Reverted
 - [v1.0.4]

--- a/source/k64f_emac.c
+++ b/source/k64f_emac.c
@@ -291,7 +291,7 @@ static void k64f_tx_reclaim(struct k64f_enetdata *k64f_enet)
   i = k64f_enet->tx_consume_index;
   while(i != k64f_enet->tx_produce_index && !(bdPtr[i].control & kEnetTxBdReady)) {
       if (k64f_enet->txb_aligned[i]) {
-        pbuf_free(k64f_enet->txb_aligned[i]);
+        memp_free(MEMP_PBUF_POOL, k64f_enet->txb_aligned[i]);
         k64f_enet->txb_aligned[i] = NULL;
       } else if (k64f_enet->txb[i]) {
         pbuf_free(k64f_enet->txb[i]);
@@ -583,7 +583,7 @@ static err_t k64f_low_level_output(struct netif *netif, struct pbuf *p)
       break;
   if (q != NULL) {
     // Allocate properly aligned buffer
-    psend = (uint8_t*)pbuf_alloc(PBUF_RAW,p->tot_len,PBUF_POOL);
+    psend = (uint8_t*)memp_malloc(MEMP_PBUF_POOL);
     if (NULL == psend)
       return ERR_MEM;
     LWIP_ASSERT("k64f_low_level_output: buffer not properly aligned", ((u32_t)psend & (TX_BUF_ALIGNMENT - 1)) == 0);

--- a/source/k64f_emac.c
+++ b/source/k64f_emac.c
@@ -291,7 +291,7 @@ static void k64f_tx_reclaim(struct k64f_enetdata *k64f_enet)
   i = k64f_enet->tx_consume_index;
   while(i != k64f_enet->tx_produce_index && !(bdPtr[i].control & kEnetTxBdReady)) {
       if (k64f_enet->txb_aligned[i]) {
-        free(k64f_enet->txb_aligned[i]);
+        pbuf_free(k64f_enet->txb_aligned[i]);
         k64f_enet->txb_aligned[i] = NULL;
       } else if (k64f_enet->txb[i]) {
         pbuf_free(k64f_enet->txb[i]);
@@ -583,7 +583,7 @@ static err_t k64f_low_level_output(struct netif *netif, struct pbuf *p)
       break;
   if (q != NULL) {
     // Allocate properly aligned buffer
-    psend = (uint8_t*)malloc(p->tot_len);
+    psend = (uint8_t*)pbuf_alloc(PBUF_RAW,p->tot_len,PBUF_POOL);
     if (NULL == psend)
       return ERR_MEM;
     LWIP_ASSERT("k64f_low_level_output: buffer not properly aligned", ((u32_t)psend & (TX_BUF_ALIGNMENT - 1)) == 0);


### PR DESCRIPTION
This PR restores v1.0.4 and replaces `pbuf_alloc` with `memp_malloc`, since the use of the buffers is raw, not structured pbufs.
